### PR TITLE
Multiple message templates

### DIFF
--- a/app/controllers/mail_controller.rb
+++ b/app/controllers/mail_controller.rb
@@ -8,8 +8,10 @@ class MailController < ApplicationController
     @page.request, @page.response = request, response
 
     config, part_page = config_and_page(@page)
+    mail_config = config.dup
+    mail_config.delete(:redirect_to)
 
-    mail = Mail.new(part_page, config, params[:mailer])
+    mail = Mail.new(part_page, mail_config, params[:mailer])
     @page.last_mail = part_page.last_mail = mail
     process_mail(mail, config)
 

--- a/app/models/mail.rb
+++ b/app/models/mail.rb
@@ -8,11 +8,12 @@ class Mail
   end
 
   def self.valid_config?(config)
-    return false if config.blank?
-    config.keys.each do |key|
-      next if key == :redirect_to
-      return false if config[key]['recipients'].blank? and config[key]['recipients_field'].blank?
-      return false if config[key]['from'].blank? and config[key]['from_field'].blank?
+    mail_config = config.dup
+    return false if mail_config.blank?
+    mail_config.delete(:redirect_to)
+    mail_config.keys.each do |key|
+      return false if mail_config[key]['recipients'].blank? and mail_config[key]['recipients_field'].blank?
+      return false if mail_config[key]['from'].blank? and mail_config[key]['from_field'].blank?
     end
     true
   end

--- a/app/models/mail.rb
+++ b/app/models/mail.rb
@@ -91,7 +91,7 @@ class Mail
       end
 
       headers = { 'Reply-To' => reply_to(config_key) || from(config_key) }
-      if sender
+      if sender(config_key)
         headers['Return-Path'] = sender(config_key)
         headers['Sender'] = sender(config_key)
       end

--- a/app/models/mail.rb
+++ b/app/models/mail.rb
@@ -10,6 +10,7 @@ class Mail
   def self.valid_config?(config)
     return false if config.blank?
     config.keys.each do |key|
+      next if key == :redirect_to
       return false if config[key]['recipients'].blank? and config[key]['recipients_field'].blank?
       return false if config[key]['from'].blank? and config[key]['from_field'].blank?
     end

--- a/app/models/mail.rb
+++ b/app/models/mail.rb
@@ -107,10 +107,9 @@ class Mail
       )
       @sent = true
     end
-    rescue Exception => e
-      errors['base'] = e.message
-      @sent = false
-    end
+  rescue Exception => e
+    errors['base'] = e.message
+    @sent = false
   end
 
   def sent?

--- a/app/models/mail.rb
+++ b/app/models/mail.rb
@@ -1,5 +1,6 @@
 class Mail
   attr_reader :page, :config, :data, :errors
+  # config can have some separate parts
   def initialize(page, config, data)
     @page, @config, @data = page, config.with_indifferent_access, data
     @required = @data.delete(:required)
@@ -7,30 +8,33 @@ class Mail
   end
 
   def self.valid_config?(config)
-    return false if config['recipients'].blank? and config['recipients_field'].blank?
-    return false if config['from'].blank? and config['from_field'].blank?
+    return false if config.blank?
+    config.keys.each do |key|
+      return false if config[key]['recipients'].blank? and config[key]['recipients_field'].blank?
+      return false if config[key]['from'].blank? and config[key]['from_field'].blank?
+    end
     true
   end
 
-  def valid?
+  def valid?(config_key)
     unless defined?(@valid)
       @valid = true
-      if recipients.blank? and !is_required_field?(config[:recipients_field])
+      if recipients(config_key).blank? and !is_required_field?(config[config_key][:recipients_field])
         errors['form'] = 'Recipients are required.'
         @valid = false
       end
 
-      if recipients.any?{|e| !valid_email?(e)}
+      if recipients(config_key).any?{|e| !valid_email?(e)}
         errors['form'] = 'Recipients are invalid.'
         @valid = false
       end
 
-      if from.blank? and !is_required_field?(config[:from_field])
+      if from(config_key).blank? and !is_required_field?(config[config_key][:from_field])
         errors['form'] = 'From is required.'
         @valid = false
       end
 
-      if !valid_email?(from)
+      if !valid_email?(from(config_key))
         errors['form'] = 'From is invalid.'
         @valid = false
       end
@@ -47,62 +51,66 @@ class Mail
     @valid
   end
 
-  def from
-    config[:from] || data[config[:from_field]]
+  def from(config_key)
+    config[config_key][:from] || data[config[config_key][:from_field]]
   end
 
-  def recipients
-    config[:recipients] || data[config[:recipients_field]].split(/,/).collect{|e| e.strip}
+  def recipients(config_key)
+    config[config_key][:recipients] || data[config[config_key][:recipients_field]].split(/,/).collect{|e| e.strip}
   end
 
-  def reply_to
-    config[:reply_to] || data[config[:reply_to_field]]
+  def reply_to(config_key)
+    config[config_key][:reply_to] || data[config[config_key][:reply_to_field]]
   end
 
-  def sender
-    config[:sender]
+  def sender(config_key)
+    config[config_key][:sender]
   end
 
-  def subject
-    data[:subject] || config[:subject] || "Form Mail from #{page.request.host}"
+  def subject(config_key)
+    data[:subject] || config[config_key][:subject] || "Form Mail from #{page.request.host}"
   end
   
-  def cc
-    data[config[:cc_field]] || config[:cc] || ""
+  def cc(config_key)
+    data[config[config_key][:cc_field]] || config[config_key][:cc] || ""
   end
   
   def send
-    return false if not valid?
+    config.keys.each do |config_key|
+      return false if not valid? config_key
 
-    plain_body = (page.part( :email ) ? page.render_part( :email ) : page.render_part( :email_plain ))
-    html_body = page.render_part( :email_html ) || nil
+      part_name = "email_#{config_key}".to_sym
+      plain_body = (page.part( part_name ) ? page.render_part( part_name ) : page.render_part( :email_plain ))
+      html_body = page.render_part( "#{part_name.to_s}_html".to_sym ) || nil
 
-    if plain_body.blank? and html_body.blank?
-      plain_body = <<-EMAIL
-The following information was posted:
-#{data.to_hash.to_yaml}
-      EMAIL
+      if plain_body.blank? and html_body.blank?
+        plain_body = <<-EMAIL
+  The following information was posted:
+  #{data.to_hash.to_yaml}
+        EMAIL
+      end
+
+      headers = { 'Reply-To' => reply_to(config_key) || from(config_key) }
+      if sender
+        headers['Return-Path'] = sender(config_key)
+        headers['Sender'] = sender(config_key)
+      end
+
+      Mailer.deliver_generic_mail(
+        :recipients => recipients(config_key),
+        :from => from(config_key),
+        :subject => subject(config_key),
+        :plain_body => plain_body,
+        :html_body => html_body,
+        :cc => cc(config_key),
+        :headers => headers
+      )
+      @sent = true
     end
-
-    headers = { 'Reply-To' => reply_to || from }
-    if sender
-      headers['Return-Path'] = sender
-      headers['Sender'] = sender
+    rescue Exception => e
+      errors['base'] = e.message
+      @sent = false
     end
-
-    Mailer.deliver_generic_mail(
-      :recipients => recipients,
-      :from => from,
-      :subject => subject,
-      :plain_body => plain_body,
-      :html_body => html_body,
-      :cc => cc,
-      :headers => headers
-    )
-    @sent = true
-  rescue Exception => e
-    errors['base'] = e.message
-    @sent = false
   end
 
   def sent?

--- a/lib/mailer_process.rb
+++ b/lib/mailer_process.rb
@@ -10,8 +10,10 @@ module MailerProcess
     # If configured to do so, receive and process the mailer POST
     if Radiant::Config['mailer.post_to_page?'] && request.post? && request.parameters[:mailer]
       config, part_page = mailer_config_and_page
+      mail_config = config.dup
+      mail_config.delete(:redirect_to)
 
-      mail = Mail.new(part_page, config, request.parameters[:mailer])
+      mail = Mail.new(part_page, mail_config, request.parameters[:mailer])
       self.last_mail = part_page.last_mail = mail
 
       if mail.send

--- a/lib/mailer_tags.rb
+++ b/lib/mailer_tags.rb
@@ -9,7 +9,7 @@ module MailerTags
         page = page.parent
       end
       string = page.render_part(:mailer)
-      (string.empty? ? {} : YAML::load(string))
+      (string.empty? ? {} : YAML::load(string).symbolize_keys)
     end
   end
 


### PR DESCRIPTION
With this modifications you can specify multiple message templates. So, you can specify emailer part like this one:

<pre>
user:
  subject: Subject1
  from: my@organization.com  
  recipients_field: email
organization:
  from: no_reply@organization.com
  subject: Subject2
  recipients:
    - my@organization.com
redirect_to: /about-us
</pre>


Each top level key (except :redirect_to) in this config means some custom email page part (like "email_key_html" for html parts or "email_key" for plain parts). So, for this configuration we must specify "email_user_html" part and "email_organization_html". With this feature you can specify as many config parts and templates as you want.
